### PR TITLE
Add Recipe Detail Screen

### DIFF
--- a/Cupboard/Cupboard.xcodeproj/project.pbxproj
+++ b/Cupboard/Cupboard.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		8B0C3DED1E1990E600EC3D7D /* CupboardUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B0C3DEC1E1990E600EC3D7D /* CupboardUITests.swift */; };
 		8B0C3DFB1E19FD8600EC3D7D /* EnterIngredientsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B0C3DFA1E19FD8600EC3D7D /* EnterIngredientsViewController.swift */; };
 		8B6DDA7D1E1B579E00229EBD /* RecipeDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B6DDA7C1E1B579E00229EBD /* RecipeDetailViewController.swift */; };
+		8B6DDA7F1E1B5F7C00229EBD /* Recipe.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B6DDA7E1E1B5F7C00229EBD /* Recipe.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -51,6 +52,7 @@
 		8B0C3DEE1E1990E600EC3D7D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		8B0C3DFA1E19FD8600EC3D7D /* EnterIngredientsViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EnterIngredientsViewController.swift; sourceTree = "<group>"; };
 		8B6DDA7C1E1B579E00229EBD /* RecipeDetailViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RecipeDetailViewController.swift; sourceTree = "<group>"; };
+		8B6DDA7E1E1B5F7C00229EBD /* Recipe.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Recipe.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -103,6 +105,7 @@
 			children = (
 				8B0C3DCC1E1990E600EC3D7D /* AppDelegate.swift */,
 				8B0C3DCE1E1990E600EC3D7D /* RecipeListViewController.swift */,
+				8B6DDA7E1E1B5F7C00229EBD /* Recipe.swift */,
 				8B0C3DFA1E19FD8600EC3D7D /* EnterIngredientsViewController.swift */,
 				8B0C3DD01E1990E600EC3D7D /* Main.storyboard */,
 				8B6DDA7C1E1B579E00229EBD /* RecipeDetailViewController.swift */,
@@ -269,6 +272,7 @@
 				8B0C3DCF1E1990E600EC3D7D /* RecipeListViewController.swift in Sources */,
 				8B6DDA7D1E1B579E00229EBD /* RecipeDetailViewController.swift in Sources */,
 				8B0C3DCD1E1990E600EC3D7D /* AppDelegate.swift in Sources */,
+				8B6DDA7F1E1B5F7C00229EBD /* Recipe.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Cupboard/Cupboard.xcodeproj/project.pbxproj
+++ b/Cupboard/Cupboard.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		8B0C3DE21E1990E600EC3D7D /* CupboardTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B0C3DE11E1990E600EC3D7D /* CupboardTests.swift */; };
 		8B0C3DED1E1990E600EC3D7D /* CupboardUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B0C3DEC1E1990E600EC3D7D /* CupboardUITests.swift */; };
 		8B0C3DFB1E19FD8600EC3D7D /* EnterIngredientsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B0C3DFA1E19FD8600EC3D7D /* EnterIngredientsViewController.swift */; };
+		8B6DDA7D1E1B579E00229EBD /* RecipeDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B6DDA7C1E1B579E00229EBD /* RecipeDetailViewController.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -49,6 +50,7 @@
 		8B0C3DEC1E1990E600EC3D7D /* CupboardUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CupboardUITests.swift; sourceTree = "<group>"; };
 		8B0C3DEE1E1990E600EC3D7D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		8B0C3DFA1E19FD8600EC3D7D /* EnterIngredientsViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EnterIngredientsViewController.swift; sourceTree = "<group>"; };
+		8B6DDA7C1E1B579E00229EBD /* RecipeDetailViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RecipeDetailViewController.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -103,6 +105,7 @@
 				8B0C3DCE1E1990E600EC3D7D /* RecipeListViewController.swift */,
 				8B0C3DFA1E19FD8600EC3D7D /* EnterIngredientsViewController.swift */,
 				8B0C3DD01E1990E600EC3D7D /* Main.storyboard */,
+				8B6DDA7C1E1B579E00229EBD /* RecipeDetailViewController.swift */,
 				8B0C3DD31E1990E600EC3D7D /* Assets.xcassets */,
 				8B0C3DD51E1990E600EC3D7D /* LaunchScreen.storyboard */,
 				8B0C3DD81E1990E600EC3D7D /* Info.plist */,
@@ -264,6 +267,7 @@
 			files = (
 				8B0C3DFB1E19FD8600EC3D7D /* EnterIngredientsViewController.swift in Sources */,
 				8B0C3DCF1E1990E600EC3D7D /* RecipeListViewController.swift in Sources */,
+				8B6DDA7D1E1B579E00229EBD /* RecipeDetailViewController.swift in Sources */,
 				8B0C3DCD1E1990E600EC3D7D /* AppDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Cupboard/Cupboard/Base.lproj/Main.storyboard
+++ b/Cupboard/Cupboard/Base.lproj/Main.storyboard
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="11762" systemVersion="16C67" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="Jl5-Wu-sxy">
-    <device id="retina4_7" orientation="portrait">
+    <device id="retina4_0" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
@@ -30,15 +30,15 @@
             <objects>
                 <tableViewController id="ebM-yE-H0E" customClass="RecipeListViewController" customModule="Cupboard" customModuleProvider="target" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="44" sectionHeaderHeight="28" sectionFooterHeight="28" id="vGf-8f-dYl">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                         <prototypes>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="RecipeItem" id="zXB-R9-aUI">
-                                <rect key="frame" x="0.0" y="28" width="375" height="44"/>
+                                <rect key="frame" x="0.0" y="28" width="320" height="44"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="zXB-R9-aUI" id="uw5-OM-14K">
-                                    <rect key="frame" x="0.0" y="0.0" width="375" height="43"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="320" height="43"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <label opaque="NO" userInteractionEnabled="NO" tag="1000" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="qhi-B7-CaN">
@@ -52,10 +52,10 @@
                                 </tableViewCellContentView>
                             </tableViewCell>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="LoadingCell" id="Ddg-XG-fak">
-                                <rect key="frame" x="0.0" y="72" width="375" height="44"/>
+                                <rect key="frame" x="0.0" y="72" width="320" height="44"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="Ddg-XG-fak" id="pRX-6h-j5B">
-                                    <rect key="frame" x="0.0" y="0.0" width="375" height="43"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="320" height="43"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <activityIndicatorView opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" fixedFrame="YES" style="gray" translatesAutoresizingMaskIntoConstraints="NO" id="49h-sH-4fr">
@@ -73,14 +73,14 @@
                                 </tableViewCellContentView>
                             </tableViewCell>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="ErrorCell" textLabel="Kbz-bR-Etf" style="IBUITableViewCellStyleDefault" id="QCg-IG-B6O">
-                                <rect key="frame" x="0.0" y="116" width="375" height="44"/>
+                                <rect key="frame" x="0.0" y="116" width="320" height="44"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="QCg-IG-B6O" id="xFI-J2-cj5">
-                                    <rect key="frame" x="0.0" y="0.0" width="375" height="43"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="320" height="43"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <label opaque="NO" multipleTouchEnabled="YES" tag="1000" contentMode="left" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="Kbz-bR-Etf">
-                                            <rect key="frame" x="15" y="0.0" width="345" height="43"/>
+                                            <rect key="frame" x="15" y="0.0" width="290" height="43"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                             <nil key="textColor"/>
@@ -115,24 +115,42 @@
             <objects>
                 <tableViewController id="AOe-fb-KLF" customClass="RecipeDetailViewController" customModule="Cupboard" customModuleProvider="target" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="grouped" separatorStyle="default" rowHeight="44" sectionHeaderHeight="18" sectionFooterHeight="18" id="diC-2c-HnX">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" cocoaTouchSystemColor="groupTableViewBackgroundColor"/>
                         <prototypes>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="RecipeInfo" textLabel="YBd-ub-o3t" style="IBUITableViewCellStyleDefault" id="ajz-Ff-PX4">
-                                <rect key="frame" x="0.0" y="56" width="375" height="44"/>
+                                <rect key="frame" x="0.0" y="56" width="320" height="44"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="ajz-Ff-PX4" id="2cr-C4-nVV">
-                                    <rect key="frame" x="0.0" y="0.0" width="375" height="43"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="320" height="43"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="YBd-ub-o3t">
-                                            <rect key="frame" x="15" y="0.0" width="345" height="43"/>
+                                            <rect key="frame" x="15" y="0.0" width="290" height="43"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                             <nil key="textColor"/>
                                             <nil key="highlightedColor"/>
                                         </label>
+                                    </subviews>
+                                </tableViewCellContentView>
+                            </tableViewCell>
+                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="LinkCell" id="t2j-CT-5fC">
+                                <rect key="frame" x="0.0" y="100" width="320" height="44"/>
+                                <autoresizingMask key="autoresizingMask"/>
+                                <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="t2j-CT-5fC" id="hYN-vu-vEG">
+                                    <rect key="frame" x="0.0" y="0.0" width="320" height="43"/>
+                                    <autoresizingMask key="autoresizingMask"/>
+                                    <subviews>
+                                        <button opaque="NO" tag="1000" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="fill" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="zcj-pZ-O3f">
+                                            <rect key="frame" x="8" y="6" width="304" height="30"/>
+                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                            <state key="normal" title="Link"/>
+                                            <connections>
+                                                <action selector="openURL" destination="AOe-fb-KLF" eventType="touchUpInside" id="LNO-nT-p17"/>
+                                            </connections>
+                                        </button>
                                     </subviews>
                                 </tableViewCellContentView>
                             </tableViewCell>
@@ -145,22 +163,22 @@
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="sRY-Qs-mIO" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="1054" y="134"/>
+            <point key="canvasLocation" x="1051.875" y="133.09859154929578"/>
         </scene>
         <!--Enter Ingredients-->
         <scene sceneID="fsH-Ah-rDp">
             <objects>
                 <tableViewController id="LUd-b7-CDz" customClass="EnterIngredientsViewController" customModule="Cupboard" customModuleProvider="target" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="grouped" separatorStyle="default" rowHeight="44" sectionHeaderHeight="18" sectionFooterHeight="18" id="sub-u2-fQd">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" cocoaTouchSystemColor="groupTableViewBackgroundColor"/>
                         <prototypes>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="IngredientEntry" id="8GS-ZN-IVw">
-                                <rect key="frame" x="0.0" y="56" width="375" height="44"/>
+                                <rect key="frame" x="0.0" y="56" width="320" height="44"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="8GS-ZN-IVw" id="U12-dY-Dp2">
-                                    <rect key="frame" x="0.0" y="0.0" width="375" height="43"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="320" height="43"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <textField opaque="NO" clipsSubviews="YES" tag="1000" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="Enter an ingredient" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="Mta-G6-lBh">

--- a/Cupboard/Cupboard/Base.lproj/Main.storyboard
+++ b/Cupboard/Cupboard/Base.lproj/Main.storyboard
@@ -114,13 +114,13 @@
         <scene sceneID="WMN-DD-LXX">
             <objects>
                 <tableViewController id="AOe-fb-KLF" customClass="RecipeDetailViewController" customModule="Cupboard" customModuleProvider="target" sceneMemberID="viewController">
-                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="44" sectionHeaderHeight="28" sectionFooterHeight="28" id="diC-2c-HnX">
+                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="grouped" separatorStyle="default" rowHeight="44" sectionHeaderHeight="18" sectionFooterHeight="18" id="diC-2c-HnX">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <color key="backgroundColor" cocoaTouchSystemColor="groupTableViewBackgroundColor"/>
                         <prototypes>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="RecipeInfo" textLabel="YBd-ub-o3t" style="IBUITableViewCellStyleDefault" id="ajz-Ff-PX4">
-                                <rect key="frame" x="0.0" y="28" width="375" height="44"/>
+                                <rect key="frame" x="0.0" y="56" width="375" height="44"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="ajz-Ff-PX4" id="2cr-C4-nVV">
                                     <rect key="frame" x="0.0" y="0.0" width="375" height="43"/>

--- a/Cupboard/Cupboard/Base.lproj/Main.storyboard
+++ b/Cupboard/Cupboard/Base.lproj/Main.storyboard
@@ -102,10 +102,41 @@
                             </connections>
                         </barButtonItem>
                     </navigationItem>
+                    <connections>
+                        <segue destination="AOe-fb-KLF" kind="show" identifier="ShowRecipe" id="wfJ-oi-Std"/>
+                    </connections>
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="bYG-OJ-VyD" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="96.799999999999997" y="133.5832083958021"/>
+        </scene>
+        <!--Recipe Detail View Controller-->
+        <scene sceneID="WMN-DD-LXX">
+            <objects>
+                <tableViewController id="AOe-fb-KLF" customClass="RecipeDetailViewController" customModule="Cupboard" customModuleProvider="target" sceneMemberID="viewController">
+                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="44" sectionHeaderHeight="28" sectionFooterHeight="28" id="diC-2c-HnX">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <prototypes>
+                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" id="ajz-Ff-PX4">
+                                <rect key="frame" x="0.0" y="28" width="375" height="44"/>
+                                <autoresizingMask key="autoresizingMask"/>
+                                <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="ajz-Ff-PX4" id="2cr-C4-nVV">
+                                    <rect key="frame" x="0.0" y="0.0" width="375" height="43"/>
+                                    <autoresizingMask key="autoresizingMask"/>
+                                </tableViewCellContentView>
+                            </tableViewCell>
+                        </prototypes>
+                        <connections>
+                            <outlet property="dataSource" destination="AOe-fb-KLF" id="Oon-UN-Hsz"/>
+                            <outlet property="delegate" destination="AOe-fb-KLF" id="9aF-ho-cRs"/>
+                        </connections>
+                    </tableView>
+                </tableViewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="sRY-Qs-mIO" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="1054" y="134"/>
         </scene>
         <!--Enter Ingredients-->
         <scene sceneID="fsH-Ah-rDp">

--- a/Cupboard/Cupboard/Base.lproj/Main.storyboard
+++ b/Cupboard/Cupboard/Base.lproj/Main.storyboard
@@ -126,7 +126,7 @@
                                     <rect key="frame" x="0.0" y="0.0" width="414" height="43.666666666666664"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
-                                        <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="YBd-ub-o3t">
+                                        <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsLetterSpacingToFitWidth="YES" id="YBd-ub-o3t">
                                             <rect key="frame" x="15" y="0.0" width="384" height="43.666666666666664"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="17"/>

--- a/Cupboard/Cupboard/Base.lproj/Main.storyboard
+++ b/Cupboard/Cupboard/Base.lproj/Main.storyboard
@@ -119,12 +119,21 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                         <prototypes>
-                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" id="ajz-Ff-PX4">
+                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="RecipeInfo" textLabel="YBd-ub-o3t" style="IBUITableViewCellStyleDefault" id="ajz-Ff-PX4">
                                 <rect key="frame" x="0.0" y="28" width="375" height="44"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="ajz-Ff-PX4" id="2cr-C4-nVV">
                                     <rect key="frame" x="0.0" y="0.0" width="375" height="43"/>
                                     <autoresizingMask key="autoresizingMask"/>
+                                    <subviews>
+                                        <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="YBd-ub-o3t">
+                                            <rect key="frame" x="15" y="0.0" width="345" height="43"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                            <nil key="textColor"/>
+                                            <nil key="highlightedColor"/>
+                                        </label>
+                                    </subviews>
                                 </tableViewCellContentView>
                             </tableViewCell>
                         </prototypes>

--- a/Cupboard/Cupboard/Base.lproj/Main.storyboard
+++ b/Cupboard/Cupboard/Base.lproj/Main.storyboard
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="11762" systemVersion="16C67" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="Jl5-Wu-sxy">
-    <device id="retina4_0" orientation="portrait">
+    <device id="retina5_5" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
@@ -30,15 +30,15 @@
             <objects>
                 <tableViewController id="ebM-yE-H0E" customClass="RecipeListViewController" customModule="Cupboard" customModuleProvider="target" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="44" sectionHeaderHeight="28" sectionFooterHeight="28" id="vGf-8f-dYl">
-                        <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="736"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                         <prototypes>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="RecipeItem" id="zXB-R9-aUI">
-                                <rect key="frame" x="0.0" y="28" width="320" height="44"/>
+                                <rect key="frame" x="0.0" y="28" width="414" height="44"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="zXB-R9-aUI" id="uw5-OM-14K">
-                                    <rect key="frame" x="0.0" y="0.0" width="320" height="43"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="414" height="43.666666666666664"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <label opaque="NO" userInteractionEnabled="NO" tag="1000" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="qhi-B7-CaN">
@@ -52,10 +52,10 @@
                                 </tableViewCellContentView>
                             </tableViewCell>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="LoadingCell" id="Ddg-XG-fak">
-                                <rect key="frame" x="0.0" y="72" width="320" height="44"/>
+                                <rect key="frame" x="0.0" y="72" width="414" height="44"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="Ddg-XG-fak" id="pRX-6h-j5B">
-                                    <rect key="frame" x="0.0" y="0.0" width="320" height="43"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="414" height="43.666666666666664"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <activityIndicatorView opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" fixedFrame="YES" style="gray" translatesAutoresizingMaskIntoConstraints="NO" id="49h-sH-4fr">
@@ -73,14 +73,14 @@
                                 </tableViewCellContentView>
                             </tableViewCell>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="ErrorCell" textLabel="Kbz-bR-Etf" style="IBUITableViewCellStyleDefault" id="QCg-IG-B6O">
-                                <rect key="frame" x="0.0" y="116" width="320" height="44"/>
+                                <rect key="frame" x="0.0" y="116" width="414" height="44"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="QCg-IG-B6O" id="xFI-J2-cj5">
-                                    <rect key="frame" x="0.0" y="0.0" width="320" height="43"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="414" height="43.666666666666664"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <label opaque="NO" multipleTouchEnabled="YES" tag="1000" contentMode="left" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="Kbz-bR-Etf">
-                                            <rect key="frame" x="15" y="0.0" width="290" height="43"/>
+                                            <rect key="frame" x="15" y="0.0" width="384" height="43.666666666666664"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                             <nil key="textColor"/>
@@ -115,19 +115,19 @@
             <objects>
                 <tableViewController id="AOe-fb-KLF" customClass="RecipeDetailViewController" customModule="Cupboard" customModuleProvider="target" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="grouped" separatorStyle="default" rowHeight="44" sectionHeaderHeight="18" sectionFooterHeight="18" id="diC-2c-HnX">
-                        <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="736"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" cocoaTouchSystemColor="groupTableViewBackgroundColor"/>
                         <prototypes>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="RecipeInfo" textLabel="YBd-ub-o3t" style="IBUITableViewCellStyleDefault" id="ajz-Ff-PX4">
-                                <rect key="frame" x="0.0" y="56" width="320" height="44"/>
+                                <rect key="frame" x="0.0" y="55.333333333333336" width="414" height="44"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="ajz-Ff-PX4" id="2cr-C4-nVV">
-                                    <rect key="frame" x="0.0" y="0.0" width="320" height="43"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="414" height="43.666666666666664"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="YBd-ub-o3t">
-                                            <rect key="frame" x="15" y="0.0" width="290" height="43"/>
+                                            <rect key="frame" x="15" y="0.0" width="384" height="43.666666666666664"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                             <nil key="textColor"/>
@@ -137,21 +137,26 @@
                                 </tableViewCellContentView>
                             </tableViewCell>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="LinkCell" id="t2j-CT-5fC">
-                                <rect key="frame" x="0.0" y="100" width="320" height="44"/>
+                                <rect key="frame" x="0.0" y="99.333333333333343" width="414" height="44"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="t2j-CT-5fC" id="hYN-vu-vEG">
-                                    <rect key="frame" x="0.0" y="0.0" width="320" height="43"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="414" height="43.666666666666664"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
-                                        <button opaque="NO" tag="1000" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="fill" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="zcj-pZ-O3f">
+                                        <button opaque="NO" tag="1000" contentMode="scaleToFill" misplaced="YES" contentHorizontalAlignment="fill" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="zcj-pZ-O3f">
                                             <rect key="frame" x="8" y="6" width="304" height="30"/>
-                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                             <state key="normal" title="Link"/>
                                             <connections>
                                                 <action selector="openURL" destination="AOe-fb-KLF" eventType="touchUpInside" id="LNO-nT-p17"/>
                                             </connections>
                                         </button>
                                     </subviews>
+                                    <constraints>
+                                        <constraint firstAttribute="trailing" secondItem="zcj-pZ-O3f" secondAttribute="trailing" constant="8" id="57k-s7-NhN"/>
+                                        <constraint firstItem="zcj-pZ-O3f" firstAttribute="top" secondItem="hYN-vu-vEG" secondAttribute="top" constant="7" id="Hrz-W7-Pcc"/>
+                                        <constraint firstItem="zcj-pZ-O3f" firstAttribute="leading" secondItem="hYN-vu-vEG" secondAttribute="leading" constant="8" id="O6b-zO-EQv"/>
+                                        <constraint firstAttribute="bottom" secondItem="zcj-pZ-O3f" secondAttribute="bottom" constant="7" id="bir-tq-UKp"/>
+                                    </constraints>
                                 </tableViewCellContentView>
                             </tableViewCell>
                         </prototypes>
@@ -170,15 +175,15 @@
             <objects>
                 <tableViewController id="LUd-b7-CDz" customClass="EnterIngredientsViewController" customModule="Cupboard" customModuleProvider="target" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="grouped" separatorStyle="default" rowHeight="44" sectionHeaderHeight="18" sectionFooterHeight="18" id="sub-u2-fQd">
-                        <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="736"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" cocoaTouchSystemColor="groupTableViewBackgroundColor"/>
                         <prototypes>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="IngredientEntry" id="8GS-ZN-IVw">
-                                <rect key="frame" x="0.0" y="56" width="320" height="44"/>
+                                <rect key="frame" x="0.0" y="55.333333333333336" width="414" height="44"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="8GS-ZN-IVw" id="U12-dY-Dp2">
-                                    <rect key="frame" x="0.0" y="0.0" width="320" height="43"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="414" height="43.666666666666664"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <textField opaque="NO" clipsSubviews="YES" tag="1000" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="Enter an ingredient" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="Mta-G6-lBh">

--- a/Cupboard/Cupboard/Recipe.swift
+++ b/Cupboard/Cupboard/Recipe.swift
@@ -1,0 +1,20 @@
+//
+//  Recipe.swift
+//  Cupboard
+//
+//  Created by Jonathan Hoffman on 1/2/17.
+//  Copyright © 2017 Jonathan Hoffman. All rights reserved.
+//
+
+import Foundation
+
+class Recipe {
+    var name = String()
+    var URL = String()
+    var ingredients = String()
+    var image = String()
+    
+    init() {
+        
+    }
+}

--- a/Cupboard/Cupboard/Recipe.swift
+++ b/Cupboard/Cupboard/Recipe.swift
@@ -11,10 +11,15 @@ import Foundation
 class Recipe {
     var name = String()
     var URL = String()
-    var ingredients = String()
+    var ingredients = [String]()
     var image = String()
     
-    init() {
-        
+    init(fromRecipeDict dict: [String : Any]) {
+        let title = dict["title"] as! String
+        name = title.replacingOccurrences(of: "\n", with: "")
+        image = dict["thumbnail"] as! String
+        URL = dict["href"] as! String
+        let dictIngredients = dict["ingredients"] as!  String
+        ingredients = dictIngredients.components(separatedBy: ", ")
     }
 }

--- a/Cupboard/Cupboard/RecipeDetailViewController.swift
+++ b/Cupboard/Cupboard/RecipeDetailViewController.swift
@@ -30,10 +30,13 @@ class RecipeDetailViewController: UITableViewController {
 
     override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         // #warning Incomplete implementation, return the number of rows
-        return 1
+        if section == 2 {
+            return recipe.ingredients.count
+        } else {
+            return 1
+        }
     }
 
-    
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell = tableView.dequeueReusableCell(withIdentifier: "RecipeInfo", for: indexPath)
 
@@ -43,7 +46,7 @@ class RecipeDetailViewController: UITableViewController {
         case 1:
             cell.textLabel!.text = recipe.image
         case 2:
-            cell.textLabel!.text = recipe.ingredients
+            cell.textLabel!.text = recipe.ingredients[indexPath.row]
         default:
             cell.textLabel!.text = recipe.name
         }

--- a/Cupboard/Cupboard/RecipeDetailViewController.swift
+++ b/Cupboard/Cupboard/RecipeDetailViewController.swift
@@ -25,23 +25,32 @@ class RecipeDetailViewController: UITableViewController {
 
     override func numberOfSections(in tableView: UITableView) -> Int {
         // #warning Incomplete implementation, return the number of sections
-        return 0
+        return 3
     }
 
     override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         // #warning Incomplete implementation, return the number of rows
-        return 0
+        return 1
     }
 
-    /*
+    
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        let cell = tableView.dequeueReusableCell(withIdentifier: "reuseIdentifier", for: indexPath)
+        let cell = tableView.dequeueReusableCell(withIdentifier: "RecipeInfo", for: indexPath)
 
-        // Configure the cell...
+        switch indexPath.section {
+        case 0:
+            cell.textLabel!.text = recipe.URL
+        case 1:
+            cell.textLabel!.text = recipe.image
+        case 2:
+            cell.textLabel!.text = recipe.ingredients
+        default:
+            cell.textLabel!.text = recipe.name
+        }
 
         return cell
     }
-    */
+    
 
     /*
     // Override to support conditional editing of the table view.

--- a/Cupboard/Cupboard/RecipeDetailViewController.swift
+++ b/Cupboard/Cupboard/RecipeDetailViewController.swift
@@ -1,0 +1,93 @@
+//
+//  RecipeDetailViewController.swift
+//  Cupboard
+//
+//  Created by Jonathan Hoffman on 1/2/17.
+//  Copyright © 2017 Jonathan Hoffman. All rights reserved.
+//
+
+import UIKit
+
+class RecipeDetailViewController: UITableViewController {
+    var recipeName: String?
+    
+    override func viewDidLoad() {
+        if let title = recipeName {
+            navigationController?.title = title
+        }
+        super.viewDidLoad()
+    }
+
+    override func didReceiveMemoryWarning() {
+        super.didReceiveMemoryWarning()
+        // Dispose of any resources that can be recreated.
+    }
+
+    // MARK: - Table view data source
+
+    override func numberOfSections(in tableView: UITableView) -> Int {
+        // #warning Incomplete implementation, return the number of sections
+        return 0
+    }
+
+    override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        // #warning Incomplete implementation, return the number of rows
+        return 0
+    }
+
+    /*
+    override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(withIdentifier: "reuseIdentifier", for: indexPath)
+
+        // Configure the cell...
+
+        return cell
+    }
+    */
+
+    /*
+    // Override to support conditional editing of the table view.
+    override func tableView(_ tableView: UITableView, canEditRowAt indexPath: IndexPath) -> Bool {
+        // Return false if you do not want the specified item to be editable.
+        return true
+    }
+    */
+
+    /*
+    // Override to support editing the table view.
+    override func tableView(_ tableView: UITableView, commit editingStyle: UITableViewCellEditingStyle, forRowAt indexPath: IndexPath) {
+        if editingStyle == .delete {
+            // Delete the row from the data source
+            tableView.deleteRows(at: [indexPath], with: .fade)
+        } else if editingStyle == .insert {
+            // Create a new instance of the appropriate class, insert it into the array, and add a new row to the table view
+        }    
+    }
+    */
+
+    /*
+    // Override to support rearranging the table view.
+    override func tableView(_ tableView: UITableView, moveRowAt fromIndexPath: IndexPath, to: IndexPath) {
+
+    }
+    */
+
+    /*
+    // Override to support conditional rearranging of the table view.
+    override func tableView(_ tableView: UITableView, canMoveRowAt indexPath: IndexPath) -> Bool {
+        // Return false if you do not want the item to be re-orderable.
+        return true
+    }
+    */
+
+    /*
+    // MARK: - Navigation
+
+    // In a storyboard-based application, you will often want to do a little preparation before navigation
+    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+        // Get the new view controller using segue.destinationViewController.
+        // Pass the selected object to the new view controller.
+    }
+    */
+
+}

--- a/Cupboard/Cupboard/RecipeDetailViewController.swift
+++ b/Cupboard/Cupboard/RecipeDetailViewController.swift
@@ -12,13 +12,20 @@ class RecipeDetailViewController: UITableViewController {
     var recipe: Recipe!
     
     override func viewDidLoad() {
-        self.title = recipe.name
         super.viewDidLoad()
     }
 
     override func didReceiveMemoryWarning() {
         super.didReceiveMemoryWarning()
         // Dispose of any resources that can be recreated.
+    }
+    
+    @IBAction func openURL() {
+        let recipeURL = URL(string: recipe.URL)
+        
+        let application = UIApplication.shared
+        
+        application.openURL(recipeURL!);
     }
 
     // MARK: - Table view data source
@@ -41,10 +48,13 @@ class RecipeDetailViewController: UITableViewController {
         let cell = tableView.dequeueReusableCell(withIdentifier: "RecipeInfo", for: indexPath)
 
         switch indexPath.section {
-        case 0:
-            cell.textLabel!.text = recipe.URL
-        case 1:
-            cell.textLabel!.text = recipe.image
+        case 0: // Name Cell
+            let cell = tableView.dequeueReusableCell(withIdentifier: "RecipeInfo", for: indexPath)
+            cell.textLabel!.text = recipe.name
+        case 1: // URL Cell
+            let cell = tableView.dequeueReusableCell(withIdentifier: "LinkCell", for: indexPath)
+            let button = cell.viewWithTag(1000) as! UIButton
+            button.setTitle(recipe.URL, for: .normal)
         case 2:
             cell.textLabel!.text = recipe.ingredients[indexPath.row]
         default:
@@ -54,6 +64,9 @@ class RecipeDetailViewController: UITableViewController {
         return cell
     }
     
+    override func tableView(_ tableView: UITableView, willSelectRowAt indexPath: IndexPath) -> IndexPath? {
+        return nil
+    }
 
     /*
     // Override to support conditional editing of the table view.

--- a/Cupboard/Cupboard/RecipeDetailViewController.swift
+++ b/Cupboard/Cupboard/RecipeDetailViewController.swift
@@ -9,12 +9,10 @@
 import UIKit
 
 class RecipeDetailViewController: UITableViewController {
-    var recipeName: String?
+    var recipe: Recipe!
     
     override func viewDidLoad() {
-        if let title = recipeName {
-            navigationController?.title = title
-        }
+        self.title = recipe.name
         super.viewDidLoad()
     }
 

--- a/Cupboard/Cupboard/RecipeListViewController.swift
+++ b/Cupboard/Cupboard/RecipeListViewController.swift
@@ -81,6 +81,21 @@ class RecipeListViewController: UITableViewController {
         }
     }
     
+    override func tableView(_ tableView: UITableView, willSelectRowAt indexPath: IndexPath) -> IndexPath? {
+        // Only allow selections when in normal recipe mode
+        guard isLoading == false, recipes.count > 0, ingredients.count > 0 else {
+            return nil
+        }
+        
+        return indexPath
+    }
+    
+    override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        let recipe = recipes[indexPath.row]
+        // Only recipe cells can be selected, so perform this segue every time
+        performSegue(withIdentifier: "ShowRecipe", sender: recipe)
+    }
+    
     override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
         if segue.identifier == "EnterIngredients" {
             // get the enter ingredient controller
@@ -89,6 +104,9 @@ class RecipeListViewController: UITableViewController {
             // initialize that controller
             controller.delegate = self
             controller.ingredients = ingredients
+        }
+        if segue.identifier == "ShowRecipe" {
+            let controller = segue.destination as! RecipeDetailViewController
         }
     }
     

--- a/Cupboard/Cupboard/RecipeListViewController.swift
+++ b/Cupboard/Cupboard/RecipeListViewController.swift
@@ -190,7 +190,7 @@ class RecipeListViewController: UITableViewController {
             // process valid dicts only
             if let recipeDict = recipeDict as? [String: Any] {
                 newRecipe.name = recipeDict["title"] as! String
-                newRecipe.name = newRecipe.name.replacingOccurrences(of: "/n", with: "")
+                newRecipe.name = newRecipe.name.replacingOccurrences(of: "\n", with: "")
                 newRecipe.image = recipeDict["thumbnail"] as! String
                 newRecipe.URL = recipeDict["href"] as! String
                 newRecipe.ingredients = recipeDict["ingredients"] as!  String

--- a/Cupboard/Cupboard/RecipeListViewController.swift
+++ b/Cupboard/Cupboard/RecipeListViewController.swift
@@ -186,14 +186,9 @@ class RecipeListViewController: UITableViewController {
         var newRecipes = [Recipe]()
         // Process each recipe in the array
         for recipeDict in recipesArray {
-            let newRecipe = Recipe()
             // process valid dicts only
             if let recipeDict = recipeDict as? [String: Any] {
-                newRecipe.name = recipeDict["title"] as! String
-                newRecipe.name = newRecipe.name.replacingOccurrences(of: "\n", with: "")
-                newRecipe.image = recipeDict["thumbnail"] as! String
-                newRecipe.URL = recipeDict["href"] as! String
-                newRecipe.ingredients = recipeDict["ingredients"] as!  String
+                let newRecipe = Recipe(fromRecipeDict: recipeDict)
                 newRecipes.append(newRecipe)
             }
         }

--- a/Cupboard/Cupboard/RecipeListViewController.swift
+++ b/Cupboard/Cupboard/RecipeListViewController.swift
@@ -9,16 +9,18 @@
 import UIKit
 
 class RecipeListViewController: UITableViewController {
-    var recipes = [String]()
+    var recipes = [Recipe]()
     var ingredients = [String]()
     // Used to indicate that the table view data is loading
-    var isLoading = true
+    var isLoading = false
     // View controller should be aware of the session data task. Used to prevent multiple searches from occuring simultaneously 
     var dataTask: URLSessionDataTask?
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        searchIngredients()
+        if ingredients.count > 0 {
+            searchIngredients()
+        }
     }
 
     override func didReceiveMemoryWarning() {
@@ -63,7 +65,7 @@ class RecipeListViewController: UITableViewController {
             
             let label = cell.viewWithTag(1000) as! UILabel
             
-            label.text = recipe
+            label.text = recipe.name
             
             return cell
         }
@@ -107,6 +109,7 @@ class RecipeListViewController: UITableViewController {
         }
         if segue.identifier == "ShowRecipe" {
             let controller = segue.destination as! RecipeDetailViewController
+            controller.recipe = sender as! Recipe
         }
     }
     
@@ -173,27 +176,28 @@ class RecipeListViewController: UITableViewController {
         }
     }
     
-    func parse(recipesFrom json: [String : Any]?) -> [String] {
+    func parse(recipesFrom json: [String : Any]?) -> [Recipe] {
         // The JSON object will have a results dict full of recipes.
         guard let recipesArray = json?["results"] as? [Any] else {
             print("Expected 'results' array")
             return []
         }
         // Store new recipes in here.
-        var recipeNames = [String]()
+        var newRecipes = [Recipe]()
         // Process each recipe in the array
         for recipeDict in recipesArray {
+            let newRecipe = Recipe()
             // process valid dicts only
             if let recipeDict = recipeDict as? [String: Any] {
-                if var recipeName = recipeDict["title"] as? String {
-                    recipeName = recipeName.replacingOccurrences(of: "\n", with: "")
-                    recipeNames.append(recipeName)
-                } else {
-                    print("Recipe title not valid")
-                }
+                newRecipe.name = recipeDict["title"] as! String
+                newRecipe.name = newRecipe.name.replacingOccurrences(of: "/n", with: "")
+                newRecipe.image = recipeDict["thumbnail"] as! String
+                newRecipe.URL = recipeDict["href"] as! String
+                newRecipe.ingredients = recipeDict["ingredients"] as!  String
+                newRecipes.append(newRecipe)
             }
         }
-        return recipeNames
+        return newRecipes
     }
 }
 


### PR DESCRIPTION
This screen adds a new table view controlled by `RecipeDetailViewController`. This is added to the navigation stack instead of being displayed modally like the ingredients list. Currently, this screen can be used to see the recipe title, a link to the full recipe, and a list of some of the key ingredients the recipe needs. 